### PR TITLE
Fix info notificaciones

### DIFF
--- a/src/main/kotlin/ar/edu/utn/frba/tacs/tp/api/herocardsgame/service/NotificationClientService.kt
+++ b/src/main/kotlin/ar/edu/utn/frba/tacs/tp/api/herocardsgame/service/NotificationClientService.kt
@@ -18,8 +18,10 @@ class NotificationClientService(val userIntegration: UserIntegration, val templa
                 ?: throw ElementNotFoundException("human user", "id", userId)
             val token = user.token
 
+            val oponent = if (match.opponent.user.id.toString() != userId) match.opponent.user else match.player.user
+
             if (token != null) {
-                this.template.convertAndSend("/topic/user/$token/notifications", NotifyResponse(match.id!!, user))
+                this.template.convertAndSend("/topic/user/$token/notifications", NotifyResponse(match.id!!, oponent))
             }
         }
     }

--- a/src/main/kotlin/ar/edu/utn/frba/tacs/tp/api/herocardsgame/service/NotificationClientService.kt
+++ b/src/main/kotlin/ar/edu/utn/frba/tacs/tp/api/herocardsgame/service/NotificationClientService.kt
@@ -39,7 +39,7 @@ class NotificationClientService(val userIntegration: UserIntegration, val templa
                         "rejections"
                     }
 
-                this.template.convertAndSend("/topic/user/$token/$destination", NotifyResponse(match.id!!, it))
+                this.template.convertAndSend("/topic/user/${it.token}/$destination", NotifyResponse(match.id!!, it))
             }
     }
 

--- a/src/main/kotlin/ar/edu/utn/frba/tacs/tp/api/herocardsgame/service/NotificationClientService.kt
+++ b/src/main/kotlin/ar/edu/utn/frba/tacs/tp/api/herocardsgame/service/NotificationClientService.kt
@@ -39,7 +39,9 @@ class NotificationClientService(val userIntegration: UserIntegration, val templa
                         "rejections"
                     }
 
-                this.template.convertAndSend("/topic/user/${it.token}/$destination", NotifyResponse(match.id!!, it))
+                val oponent = userIntegration.searchHumanUserByIdUserNameFullNameOrToken(token = token).first()
+
+                this.template.convertAndSend("/topic/user/${it.token}/$destination", NotifyResponse(match.id!!, oponent))
             }
     }
 

--- a/src/test/kotlin/ar/edu/utn/frba/tacs/tp/api/herocardsgame/service/NotificationClientServiceTest.kt
+++ b/src/test/kotlin/ar/edu/utn/frba/tacs/tp/api/herocardsgame/service/NotificationClientServiceTest.kt
@@ -97,13 +97,15 @@ internal class NotificationClientServiceTest {
                 .thenReturn(listOf(user))
             `when`(userIntegrationMock.searchHumanUserByIdUserNameFullNameOrToken(id = "1"))
                 .thenReturn(listOf(humanOpponentUser))
+            `when`(userIntegrationMock.searchHumanUserByIdUserNameFullNameOrToken(token = "humanToken"))
+                .thenReturn(listOf(humanOpponentUser))
 
             val token = humanOpponentUser.token!!
             instance.notifyConfirmMatch(token, match)
 
             verify(templateMock, times(1)).convertAndSend(
                 "/topic/user/${user.token}/confirmations",
-                NotifyResponse(match.id!!, user)
+                NotifyResponse(match.id!!, humanOpponentUser)
             )
         }
 
@@ -126,13 +128,15 @@ internal class NotificationClientServiceTest {
                 .thenReturn(listOf(user))
             `when`(userIntegrationMock.searchHumanUserByIdUserNameFullNameOrToken(id = "1"))
                 .thenReturn(listOf(humanOpponentUser))
+            `when`(userIntegrationMock.searchHumanUserByIdUserNameFullNameOrToken(token = "humanToken"))
+                .thenReturn(listOf(humanOpponentUser))
 
             val token = humanOpponentUser.token!!
             instance.notifyConfirmMatch(token, match.copy(status = MatchStatus.CANCELLED))
 
             verify(templateMock, times(1)).convertAndSend(
                 "/topic/user/${user.token}/rejections",
-                NotifyResponse(match.id!!, user)
+                NotifyResponse(match.id!!, humanOpponentUser)
             )
         }
 

--- a/src/test/kotlin/ar/edu/utn/frba/tacs/tp/api/herocardsgame/service/NotificationClientServiceTest.kt
+++ b/src/test/kotlin/ar/edu/utn/frba/tacs/tp/api/herocardsgame/service/NotificationClientServiceTest.kt
@@ -57,7 +57,7 @@ internal class NotificationClientServiceTest {
             instance.notifyCreateMatch("1", UserType.HUMAN, match)
             verify(templateMock, times(1)).convertAndSend(
                 "/topic/user/humanToken/notifications",
-                NotifyResponse(match.id!!, humanOpponentUser)
+                NotifyResponse(match.id!!, user)
             )
         }
 
@@ -102,7 +102,7 @@ internal class NotificationClientServiceTest {
             instance.notifyConfirmMatch(token, match)
 
             verify(templateMock, times(1)).convertAndSend(
-                "/topic/user/$token/confirmations",
+                "/topic/user/${user.token}/confirmations",
                 NotifyResponse(match.id!!, user)
             )
         }
@@ -131,7 +131,7 @@ internal class NotificationClientServiceTest {
             instance.notifyConfirmMatch(token, match.copy(status = MatchStatus.CANCELLED))
 
             verify(templateMock, times(1)).convertAndSend(
-                "/topic/user/$token/rejections",
+                "/topic/user/${user.token}/rejections",
                 NotifyResponse(match.id!!, user)
             )
         }


### PR DESCRIPTION
Uso este PR para meter fixes chicos que vaya encontrando en las pruebas de la integración de front al server :)

Por ahora meto: 
 * Al notificar una invitación a partida, mando en el body el usuario que generó la invitación, no el que la recibe
 * Al notificar una aceptación o rechazo de partida, lo mando al socket del que generó la invitación, no al que confirma